### PR TITLE
fix Luna 4.4 problem when 'org.apache.commons.io 2.0.1' is installed

### DIFF
--- a/fitnesseclipse.ui/META-INF/MANIFEST.MF
+++ b/fitnesseclipse.ui/META-INF/MANIFEST.MF
@@ -14,7 +14,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.jdt.core;resolution:=optional,
  org.eclipse.jdt.ui;resolution:=optional,
  org.junit;resolution:=optional,
- org.apache.commons.io;bundle-version="2.2.0"
+ org.apache.commons.io;version="[2.0.0,3.0.0)",
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: FitNesse Eclipse
 Export-Package: fitnesseclipse.ui,

--- a/fitnesseclipse.ui/META-INF/MANIFEST.MF
+++ b/fitnesseclipse.ui/META-INF/MANIFEST.MF
@@ -14,7 +14,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.jdt.core;resolution:=optional,
  org.eclipse.jdt.ui;resolution:=optional,
  org.junit;resolution:=optional,
- org.apache.commons.io;version="[2.0.0,3.0.0)",
+ org.apache.commons.io;version="[2.0.0,3.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: FitNesse Eclipse
 Export-Package: fitnesseclipse.ui,


### PR DESCRIPTION
Hi, is just had problem while installing the plug-in with Eclipse luna 4.4: 

https://marketplace.eclipse.org/content/error/report/3136407

I am not sure if you really need 'org.apache.commons.io 2.2.0' or just 2.0 >  